### PR TITLE
keyboard navigation in search modal

### DIFF
--- a/modules/App/assets/dialog/app-search.js
+++ b/modules/App/assets/dialog/app-search.js
@@ -108,13 +108,13 @@ export default {
     },
 
     template: /*html*/`
-        <div id="app-search">
+        <form id="app-search" role="search">
             <div class="kiss-flex kiss-flex-middle kiss-margin-small">
                 <div class="kiss-color-muted kiss-margin-small-right">
                     <kiss-svg :src="$base('system:assets/icons/search.svg')" width="30"><canvas width="30" height="30"></canvas></kiss-svg>
                 </div>
                 <div class="kiss-flex-1 kiss-margin-small-right">
-                    <input class="kiss-input kiss-input-blank kiss-form-large kiss-width-1-1" :class="{'kiss-disabled': loading}" type="text" v-model="search" :placeholder="t('Search...')" :disabled="loading" @keydown="keydown" @input="selected=null" ref="searchInput" style="font-size:30px;padding:0;">
+                    <input class="kiss-input kiss-input-blank kiss-form-large kiss-width-1-1" :class="{'kiss-disabled': loading}" type="search" v-model="search" :placeholder="t('Search...')" :aria-label="t('Search...')" :disabled="loading" @keydown="keydown" @input="selected=null" ref="searchInput" style="font-size:30px;padding:0;">
                 </div>
                 <button type="button" :aria-label="t('Close')" style="background:none;border:none;" class="kiss-color-muted" kiss-dialog-close>
                     <kiss-svg :src="$base('system:assets/icons/close.svg')" width="30"><canvas width="30" height="30"></canvas></kiss-svg>
@@ -148,6 +148,6 @@ export default {
 
 
             </div>
-        </div>
+        </form>
     `
 }

--- a/modules/App/assets/dialog/app-search.js
+++ b/modules/App/assets/dialog/app-search.js
@@ -70,7 +70,6 @@ export default {
         },
 
         goto(finding) {
-            console.log(finding.route)
             location.href = finding.route;
         },
 
@@ -117,9 +116,9 @@ export default {
                 <div class="kiss-flex-1 kiss-margin-small-right">
                     <input class="kiss-input kiss-input-blank kiss-form-large kiss-width-1-1" :class="{'kiss-disabled': loading}" type="text" v-model="search" :placeholder="t('Search...')" :disabled="loading" @keydown="keydown" @input="selected=null" ref="searchInput" style="font-size:30px;padding:0;">
                 </div>
-                <a class="kiss-color-muted" kiss-dialog-close>
+                <button type="button" :aria-label="t('Close')" style="background:none;border:none;" class="kiss-color-muted" kiss-dialog-close>
                     <kiss-svg :src="$base('system:assets/icons/close.svg')" width="30"><canvas width="30" height="30"></canvas></kiss-svg>
-                </a>
+                </button>
             </div>
 
             <kiss-card class="kiss-color-muted kiss-size-large kiss-align-center kiss-padding" v-if="loading">
@@ -135,13 +134,15 @@ export default {
                 <div class="kiss-text-caption kiss-color-muted kiss-margin-small">{{ t('Findings') }}</div>
 
                 <div style="max-height:50vh;overflow:auto;">
-                    <kiss-card class="kiss-padding-small kiss-flex kiss-flex-middle" :class="{'kiss-color-primary': idx == this.selected, 'kiss-color-muted': idx != this.selected}" :theme="idx == this.selected && 'contrast'" v-for="finding, idx in findings" @click="goto(finding)">
-                        <div class="kiss-margin-small-right">
-                            <kiss-svg :src="$base(finding.icon || 'system:assets/icons/link.svg')" width="20" height="20"></kiss-svg>
-                        </div>
-                        <div class="kiss-flex-1">
-                            {{ finding.title }}
-                        </div>
+                    <kiss-card class="kiss-padding-small" :theme="idx == this.selected && 'contrast'" v-for="finding, idx in findings">
+                        <a :href="finding.route" class="kiss-flex kiss-flex-middle" :class="{'kiss-color-primary': idx == this.selected, 'kiss-color-muted': idx != this.selected}">
+                            <div class="kiss-margin-small-right">
+                                <kiss-svg :src="$base(finding.icon || 'system:assets/icons/link.svg')" width="20" height="20"></kiss-svg>
+                            </div>
+                            <div class="kiss-flex-1">
+                                {{ finding.title }}
+                            </div>
+                        </a>
                     </kiss-card>
                 </div>
 


### PR DESCRIPTION
Now I can navigate with tab key and press <kbd>Enter</kbd> or use middle mouse click to open a search result in a new tab.

I also changed the close icon to a button so it has a tabindex and closes the modal on focus+Enter. The button has inline styles, which should be moved to a css file and I only tested it with Firefox, so it might need some more css resets.