### PR TITLE
prevent double loading of `field-code.js`

### DIFF
--- a/modules/App/assets/vue-components/field-object.js
+++ b/modules/App/assets/vue-components/field-object.js
@@ -1,5 +1,3 @@
-import FieldCode from "./field-code.js"
-
 export default {
 
     _meta: {
@@ -40,7 +38,9 @@ export default {
     },
 
     components: {
-        'field-code': FieldCode
+        'field-code': Vue.defineAsyncComponent(() =>
+            App.utils.import('app:assets/vue-components/field-code.js')
+        )
     },
 
     watch: {


### PR DESCRIPTION
`field-code.js` is loaded twice - one with and one without version query string.

Steps to reproduce: Go to any page, that uses `field-object` and look at the network traffic in dev tools.

Now the file is only loaded once and if I comment out `VueView.component('field-code', 'app:assets/vue-components/field-code.js');` in `components.js` for testing, the object field still works correctly.