### PR TITLE
improved uppy close button

### DIFF
--- a/modules/Assets/assets/css/uppy.css
+++ b/modules/Assets/assets/css/uppy.css
@@ -71,3 +71,17 @@
 .uppy-DashboardTab-btn:hover {
   background-color: var(--kiss-color-contrast);
 }
+
+.uppy-Dashboard-close {
+    top: 5px;
+    width: 1em;
+    height: 1em;
+    text-align: center;
+    color: var(--kiss-base-text-color);
+}
+[dir="ltr"] .uppy-Dashboard-close {
+    right: 5px;
+}
+[dir="rtl"] .uppy-Dashboard-close {
+    left: 5px;
+}


### PR DESCRIPTION
**Steps to reproduce:**

Go to `/assets` and click the button "Upload Asset".

**Issue:**

The close icon is outside of the modal, which also has a semi transparent overlay. While navigating on a mobile device, it is hard to spot that close icon. It blends in with the overlay and the app-avatar in the same space (top right).

**Solution**

I moved the icon into the modal. It also changes it's color per light/dark theme now.