### PR TITLE
Fix updating items via API

### DIFF
--- a/modules/Content/api.php
+++ b/modules/Content/api.php
@@ -189,6 +189,7 @@ $this->on('restApi.config', function($restApi) {
             // remove properties not available in the field list
 
             $allowedKeys = array_keys($default);
+            $allowedKeys[] = '_id';
 
             foreach (array_keys($data) as $key) {
                 if (!in_array($key, $allowedKeys)) unset($data[$key]);


### PR DESCRIPTION
To update an item the _id parameter must be passed to the model, or a new item will be created instead.