### PR TITLE
check for fileinfo extension

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -36,6 +36,7 @@ $checks = array(
     'Php version >= 8.0.0'                              => (version_compare(PHP_VERSION, '8.0.0') >= 0),
     'Missing PDO extension with Sqlite support'         => hasSQLiteSupport(),
     'Curl extension not available'                      => extension_loaded('curl'),
+    'Fileinfo extension not available'                  => extension_loaded('fileinfo'),
     'GD extension not available'                        => extension_loaded('gd'),
     'OpenSSL extension not available'                   => extension_loaded('openssl'),
     'Data folder is not writable: /storage/data'        => ensureWritableStorageFolder('/data'),


### PR DESCRIPTION
fileinfo is a required extension and in some cases, it might not be there, so it's probably good to check for it in the install script