### PR TITLE
Docker development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:8.0-apache as base
+
+RUN apt-get update \
+    && apt-get install -y \
+		wget zip unzip \
+        libzip-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        sqlite3 libsqlite3-dev \
+        libssl-dev \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) iconv gd pdo zip opcache pdo_sqlite \
+    && pecl install mongodb \
+    && a2enmod rewrite expires
+
+RUN echo "extension=mongodb.so" > /usr/local/etc/php/conf.d/mongodb.ini
+
+# Give www-data UID=1000 and GID=1000 to be compatible with the docker host user on linux (often 1000:1000)
+RUN usermod --uid 1000 www-data && groupmod --gid 1000 www-data && chown -R www-data:www-data /var/www/html
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+CMD ["apache2-foreground"]

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^8.0.0",
         "ext-json": "*",
+        "ext-mongodb": "*",
         "phpmailer/phpmailer": "^6.4",
         "claviska/simpleimage": "^3.6",
         "league/flysystem": "^3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+    cockpit:
+        image: cockpit-hq/cockpit:php-8.0
+        build:
+            context: .
+            target: base
+        user: www-data
+        volumes:
+            - ./:/var/www/html
+        ports:
+            - '8080:80'
+        networks:
+            - cockpit
+
+networks:
+    cockpit:
+        name: cockpit-hq


### PR DESCRIPTION
I don't have any local php installed and work with many different PHP and webservers versions.
Working with Docker to switch between all these dev environments

Setting up the environment is as simple as

```bash
docker compose up -d
```

We can access the running app at `http://localhost:8080`

We can also easily install Composer dependencies with

```bash
docker compose run --rm cockpit composer install
```

This is how I detected that the mongodb extension was missing in the `composer.json` file