### PR TITLE
filter null values in log view (broke if empty db entry exists)

### DIFF
--- a/modules/System/views/logs/index.php
+++ b/modules/System/views/logs/index.php
@@ -194,7 +194,7 @@
                         }
 
                         this.$request(`/system/logs/load`, { options }).then(rsp => {
-                            this.items = rsp.items;
+                            this.items = rsp.items.filter(item => item !== null);
                             this.page = rsp.page;
                             this.pages = rsp.pages;
                             this.count = rsp.count;


### PR DESCRIPTION
See my comment on discourse: https://discourse.getcockpit.com/t/gdpr-and-iso-27001/2528/7?u=raffaelj

@aheinze Your latest changes to MongoLite fixed the db part. This change prevents the layout from breaking if empty entries exist.

edit: I had a look at the issues. This should also solve #85.