### PR TITLE
added option to turn off user login logging

### DIFF
--- a/modules/System/admin.php
+++ b/modules/System/admin.php
@@ -55,6 +55,8 @@ $this->on('app.permissions.collect', function (ArrayObject $permissions) {
 
 $this->on('app.user.login', function($user) {
 
+    if (!$this->retrieve('log/login', true)) return;
+
     $this->module('system')->log("User Login: {$user['user']}", type: 'info', context: [
         '_id' => $user['_id'],
         'user' => $user['user'],


### PR DESCRIPTION
Usage: add `'log' => ['login' => false]` to `config.php`

I would prefer an opt-in for logging user information, but this way there is at least an easy way to turn the default behavior off. If I want to log user logins without ip address or even simpler only the user id, I can implement it in `config/bootstrap.php` or via addon.