### PR TITLE
fixed endless loop if error occurs before line 8 of file

### DIFF
--- a/modules/App/views/errors/500-debug.php
+++ b/modules/App/views/errors/500-debug.php
@@ -91,6 +91,7 @@
 
         while (true) {
             if (isset($file[($start-1)])) $start -= 1;
+            else break;
             if ($line - $start > $offset) break;
         }
     }


### PR DESCRIPTION
Steps to reproduce:

1. enable debug mode
2. Create `addons/test/bootstrap.php`

```php
<?php
$this->on('app.admin.request', function() {
    $this->bind('/test', function() {




        return 1/0;
    });
});
```

3. Login
4. Open `/test` in browser

After waiting a while and listening to my PC fans getting louder, a half rendered 500-debug view is loaded with a server timeout.