### PR TITLE
fixed missing slots in layout

### DIFF
--- a/lib/Lime/App.php
+++ b/lib/Lime/App.php
@@ -580,7 +580,7 @@ class App implements \ArrayAccess {
                 $layout = $file;
             }
 
-            $contents = $render($layout, ['content_for_layout' => $contents]);
+            $contents = $render($layout, [...$slots, 'content_for_layout' => $contents]);
         }
 
         if ($print) {


### PR DESCRIPTION
After the recent change to `App->render()`, I can't access the slots in the layout file anymore.

Usage:

layout file `default.php`:

```php
<!DOCTYPE html>
<html lang="<?=$lang?>">
    <head>
        <title><?=$title?></title>
    </head>
    <body>
        <?=$content_for_layout?>
    </body>
</html>
```

view file `page.php`:

```php
<h1><?=$title?></h1>
<?=$content?>
```

Calling render method:

```php
$app->render('source:page.php with source:default.php', [
    'lang'    => 'en',
    'title'   => 'Cats',
    'content' => '<p>are cute</p>'
]);
```