### PR TITLE
allow layout inheritance, added $viewVars

### DIFF
--- a/lib/Lime/App.php
+++ b/lib/Lime/App.php
@@ -51,7 +51,7 @@ class App implements \ArrayAccess {
     public mixed $layout = false;
 
     /* global view variables */
-    public array $viewvars = [];
+    public array $viewVars = [];
 
     /**
     * Constructor
@@ -558,7 +558,7 @@ class App implements \ArrayAccess {
                 $this->trigger("app.render.view/{$view}", [&$view, &$slots]);
             }
 
-            $slots = \array_merge($this->viewvars, $slots);
+            $slots = \array_merge($this->viewVars, $slots);
 
             $layout = $this->layout;
         }


### PR DESCRIPTION
Allow layout inheritance, e. g.:

* `page.php` has layout `default.php`
* `post.php` has layout `blog.php`, which itself has layout `default.php`

Alternative syntax:

* `$this->render('views:page.php with layouts:default.php')`
* `$this->render('views:post.php with layouts:blog.php with layouts:default.php')`

I also added `$viewVars`, which were dropped during the rewrite from v1 to v2.

The slots, that are passed to the initial call of `render($view, $slots)`, are available in all parent/stacked layouts.

I added some more context in the discussion of #135.

Closes #135.