### PR TITLE
pass initial config to async worker

### DIFF
--- a/lib/Lime/App.php
+++ b/lib/Lime/App.php
@@ -76,6 +76,8 @@ class App implements \ArrayAccess {
             'site_url'     => null
         ], $settings);
 
+        $this->registry['initialConfig'] = $settings;
+
         // app modules container
         $this->registry['modules'] = new ArrayObject([]);
 

--- a/modules/App/Helper/Async.php
+++ b/modules/App/Helper/Async.php
@@ -60,7 +60,7 @@ function Cockpit() {
     static \$instance;
 
     if (!isset(\$instance)) {
-        \$instance = Cockpit::instance('{$envDir}');
+        \$instance = Cockpit::instance('{$envDir}', ".\var_export($this->app['initialConfig'], true).");
         \$GLOBALS['APP'] = \$instance;
     }
 


### PR DESCRIPTION
Right now, the async worker scripts aren't aware of a few config values.

See `index.php`:

```php
$app = Cockpit::instance($APP_SPACE_DIR, [
    // These three values are unknown in async worker:
    'app_space'  => $APP_SPACE,
    'base_route' => $APP_BASE_ROUTE,
    'base_url'   => $APP_BASE_URL
]);
```

This modification also enables advanced usage of Cockpit by loading it as a library (via composer) and/or working with custom folder patterns.

Simple example with modified `index.php`:

```php
$app = Cockpit::instance($APP_SPACE_DIR, [
    'app_space'  => $APP_SPACE,
    'base_route' => $APP_BASE_ROUTE,
    'base_url'   => $APP_BASE_URL,

    // store sensitive data above document root
    // without this change, the custom paths are lost when an async task runs
    'paths' => [
        '#config'  => dirname(__DIR__) . '/config',
        '#storage' => dirname(__DIR__) . '/storage',
    ],
]);
```