### PR TITLE
Add meta fields to GraphQL model definitions

### DIFF
--- a/modules/Content/graphql/models.php
+++ b/modules/Content/graphql/models.php
@@ -24,9 +24,9 @@ foreach ($collections as $name => &$meta) {
                     '_id'       => Type::nonNull(Type::string()),
                     '_state'    => Type::nonNull(Type::int()),
                     '_o'        => Type::nonNull(Type::int()),
-                    '_cby'      => Type::nonNull(Type::ID()),
+                    '_cby'      => Type::nonNull(Type::string()),
                     '_created'  => Type::nonNull(Type::int()),
-                    '_mby'      => Type::nonNull(Type::ID()),
+                    '_mby'      => Type::nonNull(Type::string()),
                     '_modified' => Type::nonNull(Type::int())
                 ], $meta['type'] === 'tree' ? [
                     '_pid'      => Type::string()
@@ -106,9 +106,9 @@ foreach ($singletons as $name => &$meta) {
                 $fields = array_merge([
                     '_id'       => Type::string(),
                     '_state'    => Type::int(),
-                    '_cby'      => Type::ID(),
+                    '_cby'      => Type::string(),
                     '_created'  => Type::int(),
-                    '_mby'      => Type::ID(),
+                    '_mby'      => Type::string(),
                     '_modified' => Type::int()
                 ], FieldTypes::buildFieldsDefinitions($meta));
 

--- a/modules/Content/graphql/models.php
+++ b/modules/Content/graphql/models.php
@@ -23,12 +23,12 @@ foreach ($collections as $name => &$meta) {
                 $fields = array_merge([
                     '_id'       => Type::nonNull(Type::string()),
                     '_state'    => Type::nonNull(Type::int()),
-                    '_o'        => Type::nonNull(Type::int()),
                     '_cby'      => Type::nonNull(Type::string()),
                     '_created'  => Type::nonNull(Type::int()),
                     '_mby'      => Type::nonNull(Type::string()),
                     '_modified' => Type::nonNull(Type::int())
                 ], $meta['type'] === 'tree' ? [
+                    '_o'        => Type::nonNull(Type::int()),
                     '_pid'      => Type::string()
                 ] : [], FieldTypes::buildFieldsDefinitions($meta));
 

--- a/modules/Content/graphql/models.php
+++ b/modules/Content/graphql/models.php
@@ -22,9 +22,15 @@ foreach ($collections as $name => &$meta) {
 
                 $fields = array_merge([
                     '_id'       => Type::nonNull(Type::string()),
+                    '_state'    => Type::nonNull(Type::int()),
+                    '_o'        => Type::nonNull(Type::int()),
+                    '_cby'      => Type::nonNull(Type::ID()),
                     '_created'  => Type::nonNull(Type::int()),
+                    '_mby'      => Type::nonNull(Type::ID()),
                     '_modified' => Type::nonNull(Type::int())
-                ], FieldTypes::buildFieldsDefinitions($meta));
+                ], $meta['type'] === 'tree' ? [
+                    '_pid'      => Type::string()
+                ] : [], FieldTypes::buildFieldsDefinitions($meta));
 
                 return $fields;
             }
@@ -98,9 +104,12 @@ foreach ($singletons as $name => &$meta) {
             'fields' => function() use($meta, $app, $_name) {
 
                 $fields = array_merge([
-                    '_id' => Type::string(),
-                    '_created' => Type::int(),
-                    '_modified' =>Type::int()
+                    '_id'       => Type::string(),
+                    '_state'    => Type::int(),
+                    '_cby'      => Type::ID(),
+                    '_created'  => Type::int(),
+                    '_mby'      => Type::ID(),
+                    '_modified' => Type::int()
                 ], FieldTypes::buildFieldsDefinitions($meta));
 
                 return $fields;


### PR DESCRIPTION
Fixes inconsistency in provided meta fields/properties between REST API and GraphQL API. Following properties are added to GraphQL model definitions:

- `_state` (Collection, Singleton, Tree)
- `_o` (Collection, Tree)
- `_mby` (Collection, Singleton, Tree)
- `_cby` (Collection, Singleton, Tree)
- `_pid` (Tree)

Context: [https://discourse.getcockpit.com/t/help-where-to-find-relations-when-getting-content-item-of-type-tree/2450/4](https://discourse.getcockpit.com/t/help-where-to-find-relations-when-getting-content-item-of-type-tree/2450/4)