### PR TITLE
fix: move webhook trigger above the pagination condition

### DIFF
--- a/modules/Content/api.php
+++ b/modules/Content/api.php
@@ -478,6 +478,10 @@ $this->on('restApi.config', function($restApi) {
 
             $items = $app->module('content')->items($model, $options, $process);
 
+            if (count($items)) {
+                $app->trigger('content.api.items', [&$items, $model]);
+            }
+
             if (isset($options['skip'], $options['limit'])) {
                 return [
                     'data' => $items,
@@ -485,10 +489,6 @@ $this->on('restApi.config', function($restApi) {
                         'total' => $app->module('content')->count($model, $options['filter'] ?? [])
                     ]
                 ];
-            }
-
-            if (count($items)) {
-                $app->trigger('content.api.items', [&$items, $model]);
             }
 
             return $items;


### PR DESCRIPTION
**Issue** 
If the API has `limit` parameter, webhook doesn't trigger anymore. 