### PR TITLE
Translit unicode chars in filename instead of removing them

### DIFF
--- a/modules/Assets/bootstrap.php
+++ b/modules/Assets/bootstrap.php
@@ -149,7 +149,9 @@ $this->module('assets')->extend([
             // clean filename
             $filename = pathinfo($file, PATHINFO_FILENAME);
             $ext = pathinfo($file, PATHINFO_EXTENSION);
-            $cleanFilename = preg_replace('/[^a-zA-Z0-9-_\.]/','', str_replace(' ', '-', $filename));
+            setlocale(LC_ALL, "en-US.utf8"); // set correct locale for iconv
+            $cleanFilename = iconv('utf-8', 'us-ascii//TRANSLIT', $filename);
+            $cleanFilename = preg_replace('/[^a-zA-Z0-9-_\.]/', '', str_replace(' ', '-', $cleanFilename));
             $clean = $cleanFilename.uniqid("_uid_").'.'.$ext;
             $path  = '/'.date('Y/m/d').'/'.$clean;
 


### PR DESCRIPTION
This change will translit unicode characters instead of removing them.

For example filename `Příliš žluťoučký kůň úpěl ďábelské ódy.pdf` is currently saved as `Pli-luouk-k-pl-belsk-dy.pdf`.

After this change, it will be saved as `Prilis-zlutoucky-kun-upel-dabelske-ody.pdf`.