### PR TITLE
Maintenance mode from CONFIG file

### DIFF
--- a/modules/App/Helper/Acl.php
+++ b/modules/App/Helper/Acl.php
@@ -35,6 +35,10 @@ class Acl extends \Lime\Helper {
 
         $role = $role ?? $this->app->helper('auth')->getUser('role');
 
+        if ($this->app['maintenance']) {
+            return false;
+        }
+
         if ($this->isSuperAdmin($role)) {
             return true;
         }

--- a/modules/App/Helper/Acl.php
+++ b/modules/App/Helper/Acl.php
@@ -35,12 +35,11 @@ class Acl extends \Lime\Helper {
 
         $role = $role ?? $this->app->helper('auth')->getUser('role');
 
-        if ($this->app['maintenance']) {
-            return false;
-        }
-
         if ($this->isSuperAdmin($role)) {
             return true;
+        }
+        else if ($this->app['maintenance'] && !preg_match('/\/read$/', $permission)) {
+            return false;
         }
 
         return isset($this->roles[$role]['permissions'][$permission]) && $this->roles[$role]['permissions'][$permission];

--- a/modules/App/views/auth/login.php
+++ b/modules/App/views/auth/login.php
@@ -9,7 +9,7 @@
                     <div><img class="app-logo" src="<?= $this->helper('theme')->logo() ?>" style="height:40px;width:auto;" alt="Logo"></div>
                     <div>
                         <strong class="kiss-size-5"><?= $this['app.name'] ?></strong>
-                        <div class="kiss-color-muted kiss-size-xsmall kiss-margin-xsmall"><?= t('Log in to your account') ?></div>
+                        <div class="kiss-color-muted kiss-size-xsmall kiss-margin-xsmall"><?= $this['maintenance']?:t('Log in to your account') ?></div>
                     </div>
                 </div>
 
@@ -32,16 +32,6 @@
                     <?php endif ?>
 
                 </form>
-
-                <kiss-card class="animated fadeIn" v-show="<?= isset($this['maintenance']) ?>">
-
-                    <kiss-row class="kiss-flex-middle">
-                        <div class="kiss-size-small">
-                            <div class="kiss-text-bold"><?= $this['maintenance'] ?></div>
-                       </div>
-                    </kiss-row>
-
-                </kiss-card>
 
                 <kiss-card class="animated fadeIn" v-if="!loading && view=='success' && !user.twofa">
 

--- a/modules/App/views/auth/login.php
+++ b/modules/App/views/auth/login.php
@@ -13,7 +13,7 @@
                     </div>
                 </div>
 
-                <form :class="{'kiss-disabled': loading}" @submit.prevent="login" v-if="view=='form'">
+                <form :class="{'kiss-disabled': loading}" @submit.prevent="login" v-if="view=='form'" v-show="<?= !isset($this['maintenance']) ?>">
 
                     <div class="kiss-margin">
                         <input class="kiss-input" type="text" placeholder="<?= t('Username or Email') ?>" aria-label="<?= t('Username or Email') ?>" v-model="auth.user" autocomplete="off" autofocus required>
@@ -32,6 +32,16 @@
                     <?php endif ?>
 
                 </form>
+
+                <kiss-card class="animated fadeIn" v-show="<?= isset($this['maintenance']) ?>">
+
+                    <kiss-row class="kiss-flex-middle">
+                        <div class="kiss-size-small">
+                            <div class="kiss-text-bold"><?= $this['maintenance'] ?></div>
+                       </div>
+                    </kiss-row>
+
+                </kiss-card>
 
                 <kiss-card class="animated fadeIn" v-if="!loading && view=='success' && !user.twofa">
 

--- a/modules/App/views/errors/401.php
+++ b/modules/App/views/errors/401.php
@@ -25,6 +25,7 @@
         <h1>401</h1>
 
         <p class="kiss-margin kiss-color-muted"><?=t('Unauthorized request')?></p>
+        <p v-show="<?= isset($this['maintenance']) ?>" class="kiss-margin kiss-color-muted"><?= $this['maintenance'] ?></p>
 
     </kiss-container>
 


### PR DESCRIPTION
Hi, I made a small fix in the code, in case someone wants to do maintenance on the live environment and needs to disable login/editing. The setting is done via the CONFIG file, so it doesn't need to change the localization.

**CONFIG.PHP**
```
return [
'maintenance' => 'Oops! Under maintenance.'
];
```

This setting is checked
- when logging in, it just hides the login window
- when checking the role, function isAllowed
- displaying a 401 error, where information about system maintenance is added

What do you think about it?
Resolves #206