### PR TITLE
Fix navigationField update: Emit 'update:modelValue' event in addItem

### DIFF
--- a/modules/App/assets/vue-components/fields/field-nav.js
+++ b/modules/App/assets/vue-components/fields/field-nav.js
@@ -186,6 +186,8 @@ export default {
                 data,
                 children: []
             });
+            
+            this.emitUpdate();
         },
 
         edit(item) {
@@ -199,6 +201,10 @@ export default {
             this.val.splice(this.val.indexOf(item), 1);
             this.update();
         },
+
+        emitUpdate() {
+            this.$emit('update:modelValue', this.val);
+        }
 
     },
 


### PR DESCRIPTION
### Summary
This PR addresses an issue where the navigationField component was not updating correctly when a new item was added. The problem was caused by the model not being updated after an item was pushed into the collection.

### Changes
- In the file `modules/App/Assets/vue-components/fields/field-nav.js`, the `addItem` function has been modified.
- After pushing a new item into the collection, the function now emits the `update:modelValue` event with the updated model value (`this.val`).

### Testing
- Verified that the new navigation item appears correctly and the UI reflects the change immediately.
- Confirmed that the `update:modelValue` event is fired, ensuring proper two-way data binding in the component.

### Additional Context
This change ensures that the component’s model is updated whenever a new navigation item is added, resolving the bug where the navigationField did not function as expected.