### PR TITLE
fix: shell command built from environment values Improper Neutralization lead an command injection

### DIFF
--- a/modules/App/assets/build.bundle.js
+++ b/modules/App/assets/build.bundle.js
@@ -24,10 +24,18 @@ postcss()
         fs.writeFileSync(__dirname + '/app.bundle.css', result.css)
     })
 
-exec(`rollup ${__dirname}/js/app.js --file ${__dirname}/app.bundle.js  --plugin @rollup/plugin-terser --format iife`, (err, stdout, stderr) => {
+const execFile = require('child_process').execFile;
 
+const rollupArgs = [
+    `${__dirname}/js/app.js`,
+    '--file', `${__dirname}/app.bundle.js`,
+    '--plugin', '@rollup/plugin-terser',
+    '--format', 'iife'
+];
+
+execFile('rollup', rollupArgs, (err, stdout, stderr) => {
     if (err) {
-        console.log(err)
+        console.log(err);
         return;
     }
 


### PR DESCRIPTION
https://github.com/Cockpit-HQ/Cockpit/blob/1650737d73ebe2712f81c88ced81d9cece4abbf3/modules/App/assets/build.bundle.js#L27-L27
https://github.com/Cockpit-HQ/Cockpit/blob/1650737d73ebe2712f81c88ced81d9cece4abbf3/modules/App/assets/build.bundle.js#L30-L30
constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.



fix the issue, the shell command should be constructed in a way that avoids interpretation by the shell. This can be achieved by using `execFile` or `execFileSync` from the `child_process` module, which allows passing arguments separately instead of embedding them in a single string. This approach ensures that special characters in paths are handled safely and prevents command injection vulnerabilities.
1. Replace the use of `exec` with `execFile`.
2. Pass the command (`rollup`) and its arguments as separate parameters to `execFile`.
3. Ensure that all paths and arguments are properly escaped or handled as separate arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the method used to run the build process, with no impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->