### PR TITLE
Added support for Spaces #2

### DIFF
--- a/modules/Identi/admin.php
+++ b/modules/Identi/admin.php
@@ -22,7 +22,14 @@ $this->on('app.user.logout.after', function($user, $params, $data) {
 
     if ($idTokenHint) {
         try {
-            $this->module('identi')->getOIDCClient()->signOut($idTokenHint, $this->getSiteUrl(true).'/auth/login');
+            $signoutUrl = $this->getSiteUrl(true) . '/auth/login';
+
+            if (!$this->helper('spaces')->isMaster()) {
+                $space = basename(trim($this->path('#root:'), '/'));
+                $signoutUrl = $this->getSiteUrl(true) . "/:{$space}/auth/login";
+            }           
+            
+            $this->module('identi')->getOIDCClient()->signOut($idTokenHint, $signoutUrl);
         } catch (Exception $e) {}
     }
 });


### PR DESCRIPTION
The logout-URL will always redirect to the master-space's login. This change will add support for custom-spaces and will redirect to the correct space-login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sign-out process to ensure users are redirected to the correct login page based on their current space context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->