### PR TITLE
Fix icons path

### DIFF
--- a/modules/System/Controller/Utils.php
+++ b/modules/System/Controller/Utils.php
@@ -85,7 +85,7 @@ class Utils extends App {
 
                 $icons[] = [
                     'name' => $f->getBasename('.svg'),
-                    'path' => $p.str_replace($path, '', $f->getRealPath()),
+                    'path' => $p.str_replace([DIRECTORY_SEPARATOR, $path], ['/', ''], $f->getPathname()),
                 ];
             }
 


### PR DESCRIPTION
Fix icons path in Assets, second attempt 😊 Tested locally on Windows via OpenServer Panel 6

<img width="850" height="600" alt="image" src="https://github.com/user-attachments/assets/251d8a4e-b68b-4eb3-95bf-085b9871660e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized icon paths to use forward slashes and be relative to the base directory, ensuring consistent behavior across operating systems.
  * Resolved issues where icons could fail to load or display incorrect paths on Windows.
  * Improved consistency of icon listings and filtering regardless of environment.
  * Reduced path-related discrepancies between development and production setups, leading to more reliable asset referencing and fewer broken icon links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->