### PR TITLE
fix: reject unvalidated JWT tokens to prevent API auth bypass

### DIFF
--- a/modules/App/api.php
+++ b/modules/App/api.php
@@ -56,7 +56,9 @@ $this->bind('/api/*', function($params) {
     // is jwt token?
     } elseif ($token != 'public' && preg_match('/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/', $token)) {
 
-            // todo
+            // JWT token validation is not yet implemented — reject to prevent auth bypass
+            $this->response->status = 401;
+            return ['error' => 'JWT authentication is not supported'];
 
     } else {
 


### PR DESCRIPTION
## Summary

Reject JWT-format tokens in the API authentication handler to prevent authentication bypass.

## Problem

In `modules/App/api.php`, the API authentication flow has three branches:

1. `USR-` prefixed tokens → validated against user records
2. JWT-format tokens → **`// todo` — no validation, no error**
3. All other tokens → validated against API keys

The JWT branch (line ~50) matches tokens that look like JWTs but performs no validation:

```php
} elseif ($token != 'public' && preg_match('/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/', $token)) {
    // todo
}
```

Because there is no `return` or error response, execution continues past this block with `$apiUser` set to `['user' => 'anonymous', 'role' => null]`. The API key validation in the `else` branch is **never reached** for JWT-format tokens.

This means any request with a fake JWT token (e.g., `Authorization: Bearer aaa.bbb.ccc`) bypasses both:
- User API key validation (`USR-` check)
- API key validation (the `else` block)

The request proceeds with `role: null`, and depending on how ACL checks handle null roles, this could grant unintended access to API endpoints.

## Fix

Return a `401 Unauthorized` error for JWT-format tokens until proper JWT validation is implemented:

```php
$this->response->status = 401;
return ['error' => 'JWT authentication is not supported'];
```

## Impact

- **Type**: Authentication Bypass (CWE-287)
- **Affected file**: `modules/App/api.php`
- **Risk**: Any request with a fake JWT token bypasses API key validation
- **OWASP**: A07:2021 — Identification and Authentication Failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API now properly rejects authentication attempts using JWT token format requests with a `401 Unauthorized` response and a clear error message indicating JWT authentication is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->