### PR TITLE
Fix: require assets/edit permission to replace an asset (#303)

### DIFF
--- a/modules/Assets/Controller/Assets.php
+++ b/modules/Assets/Controller/Assets.php
@@ -192,7 +192,7 @@ class Assets extends App {
         $this->helper('session')->close();
         $this->hasValidCsrfToken(true);
 
-        if (!$this->isAllowed('assets/upload')) {
+        if (!$this->isAllowed('assets/upload') || !$this->isAllowed('assets/edit')) {
             return $this->stop(['error' => 'Upload not allowed'], 401);
         }
 


### PR DESCRIPTION
## What changed

`Assets::replace()` only checked `assets/upload` before allowing a user to overwrite an existing asset's file. `Assets::update()` (which edits an asset's metadata) correctly requires `assets/edit`. This meant a role with **Upload** rights but not **Edit** rights could still replace the binary content of any existing asset via the "Replace" button in the asset details view, bypassing the Edit permission entirely.

Fix: `replace()` now requires both `assets/upload` and `assets/edit`, matching the intent described in the issue and mirroring `update()`'s pattern.

```php
// before
if (!$this->isAllowed('assets/upload')) {
    return $this->stop(['error' => 'Upload not allowed'], 401);
}

// after
if (!$this->isAllowed('assets/upload') || !$this->isAllowed('assets/edit')) {
    return $this->stop(['error' => 'Upload not allowed'], 401);
}
```

## Why this doesn't break upload-only workflows

Checked `modules/Assets/admin.php`'s `app.permissions.collect` handler and the roles UI (`modules/System/views/users/roles/role.php`): `assets/upload`, `assets/edit`, `assets/delete`, etc. are independently toggleable checkboxes with no default coupling, seed data, or implicit-grant logic anywhere in the codebase tying "upload" to "edit/replace an existing asset". There is no documented or seeded "upload-only roles may replace their own uploads" convention — every role's permission set is configured explicitly by an admin per-checkbox. So requiring `assets/edit` in addition to `assets/upload` for `replace()` does not silently break any existing, intentional workflow; it closes an ACL bypass that let an upload-only role overwrite arbitrary existing asset files without edit rights.

## Test plan

- Repo has no PHPUnit/test suite or CI workflow to run (verified: no `phpunit.xml`, no `tests/` directory, no `.github/workflows`), so no existing automated tests cover this controller.
- Verified `php -l` syntax check passes on the modified file (PHP 8.3, matching `composer.json`'s `"php": "^8.3.0"` requirement).
- Manually traced the code path: `replace()` now short-circuits with a 401 `Upload not allowed` response unless the caller holds both `assets/upload` and `assets/edit`, identical gating behavior to `update()`.

Closes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset replacement now requires both upload and edit permissions, improving access control and preventing unauthorized changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->