### PR TITLE
Add link back to start page on 404 error page (#107)

### DIFF
--- a/modules/App/views/errors/404.php
+++ b/modules/App/views/errors/404.php
@@ -36,6 +36,10 @@
 
         <p class="kiss-margin kiss-color-muted"><?=t('Requested resource is not available')?></p>
 
+        <p class="kiss-margin">
+            <a href="<?=$this->route('/')?>"><?=t('Back to start page')?></a>
+        </p>
+
     </kiss-container>
 
 </body>


### PR DESCRIPTION
## What
Adds a link back to the start page (admin dashboard root) on the 404 error page (`modules/App/views/errors/404.php`).

## Why
Closes #107. Currently the 404 page is a dead end — no way to navigate back into the app without manually editing the URL.

## Implementation notes
- Used the `$this->route('/')` helper for the link target, matching the existing pattern used elsewhere in the codebase for linking to the dashboard/start page (see `modules/App/layouts/app.php`, e.g. `<a href="<?= $this->route('/') ?>" aria-label="<?= t('Dashboard') ?>">`). This resolves to the admin dashboard root, which is the correct "start page" target given this view lives under `modules/App/views/errors/` (the admin-side error view) — there is no separate public-site 404 template in the codebase.
- Label uses the file's existing i18n convention: `t('Back to start page')`.
- No other 404/error views in the repo needed changes; this is the only 404 template.

## Testing
- `php -l` syntax check passed (PHP 8.3, matching the `composer.json` `"php": "^8.3.0"` requirement), via `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php -l modules/App/views/errors/404.php`.
- Manual review confirms the added markup follows the existing markup/whitespace conventions in the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a link on the 404 error page to return to the start page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->